### PR TITLE
Fix plugins + Bump dependencies

### DIFF
--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
@@ -12,17 +12,17 @@ object Versions {
 
     const val androidGradle                 = "4.2.0"
     const val arch                          = "2.1.0"
-    const val camera                        = "1.1.0-alpha08"
-    const val cameraView                    = "1.0.0-alpha28"
+    const val camera                        = "1.1.0-alpha09"
+    const val cameraView                    = "1.0.0-alpha29"
     const val coil                          = "1.3.2"
     const val coroutines                    = "1.5.2"
     const val lifecycle                     = "2.3.1"
-    const val hilt                          = "2.38"
+    const val hilt                          = "2.39.1"
     const val hiltJetpack                   = "1.0.0-alpha03"
-    const val kotlin                        = "1.5.30"
+    const val kotlin                        = "1.5.31"
     const val moshi                         = "1.12.0"
     const val navigation                    = "2.3.5"
-    const val okhttp                        = "4.9.1"
+    const val okhttp                        = "4.9.2"
     const val sqlDelight                    = "1.5.1"
 }
 
@@ -40,7 +40,7 @@ object Deps {
             const val view                  = "androidx.camera:camera-view:${Versions.cameraView}"
         }
 
-        const val constraintLayout          = "androidx.constraintlayout:constraintlayout:2.1.0"
+        const val constraintLayout          = "androidx.constraintlayout:constraintlayout:2.1.1"
         const val core                      = "androidx.core:core-ktx:1.6.0"
         const val exifInterface             = "androidx.exifinterface:exifinterface:1.3.3"
 
@@ -191,7 +191,7 @@ object TestDeps {
 
     object google {
         const val hilt                      = "com.google.dagger:hilt-android-testing:${Versions.hilt}"
-        const val guava                     = "com.google.guava:guava:30.1.1-jre"
+        const val guava                     = "com.google.guava:guava:31.0.1-jre"
     }
 
     const val junit                         = "junit:junit:4.12"

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
@@ -12,8 +12,8 @@ object Versions {
 
     const val androidGradle                 = "4.2.0"
     const val arch                          = "2.1.0"
-    const val camera                        = "1.1.0-alpha09"
-    const val cameraView                    = "1.0.0-alpha29"
+    const val camera                        = "1.1.0-alpha08"
+    const val cameraView                    = "1.0.0-alpha28"
     const val coil                          = "1.3.2"
     const val coroutines                    = "1.5.2"
     const val lifecycle                     = "2.3.1"

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/Extensions.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/Extensions.kt
@@ -17,9 +17,10 @@ package io.matthewnelson.components.kmp
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun Project.kotlin(action: Action<KotlinMultiplatformExtension>) {
-    extensions.configure(KotlinMultiplatformExtension::class.java, action)
+    extensions.configure(KotlinMultiplatformExtension::class, action)
 }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
@@ -52,6 +52,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
             KmpTarget.NON_JVM.JS.ENV_PROPERTY_VALUE,
 
             // darwin
+            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ALL.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM32.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM64.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.X64.ENV_PROPERTY_VALUE,
@@ -60,10 +61,12 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.MACOS.X64.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.MACOS.ARM64.ENV_PROPERTY_VALUE,
 
+            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.ALL.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.ARM64.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.X64.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.SIMULATOR_ARM64.ENV_PROPERTY_VALUE,
 
+            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ALL.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ARM32.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ARM64.ENV_PROPERTY_VALUE,
             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.X64.ENV_PROPERTY_VALUE,
@@ -193,6 +196,66 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
 
                         val darwinTargets = unixTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN>()
                         if (darwinTargets.isNotEmpty()) {
+
+                            val iosTargets = darwinTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS>()
+                            val tvosTargets = darwinTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS>()
+                            val watchOsTargets = darwinTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS>()
+
+                            var simulatorCount = 0
+                            var containsAll: Boolean = false
+                            for (target in iosTargets) {
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ALL) {
+                                    containsAll = true
+                                }
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.SIMULATOR_ARM64) {
+                                    simulatorCount = 1
+                                }
+                            }
+
+                            // ensure IOS.ALL is only target passed
+                            if (containsAll) {
+                                if (iosTargets.size > (1 + simulatorCount)) {
+                                    throw IllegalArgumentException("IOS.ALL cannot be used along with other IOS targets")
+                                }
+                                containsAll = false
+                            }
+
+                            simulatorCount = 0
+                            for (target in tvosTargets) {
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.ALL) {
+                                    containsAll = true
+                                }
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.SIMULATOR_ARM64) {
+                                    simulatorCount = 1
+                                }
+                            }
+
+                            // ensure TVOS.ALL is only target passed
+                            if (containsAll) {
+                                if (tvosTargets.size > (1 + simulatorCount)) {
+                                    throw IllegalArgumentException("TVOS.ALL cannot be used along with other TVOS targets")
+                                }
+                                containsAll = false
+                            }
+
+                            simulatorCount = 0
+                            for (target in watchOsTargets) {
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ALL) {
+                                    containsAll = true
+                                }
+                                if (target is KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.SIMULATOR_ARM64) {
+                                    simulatorCount = 1
+                                }
+                            }
+
+                            // ensure TVOS.ALL is only target passed
+                            if (containsAll) {
+                                if (watchOsTargets.size > (1 + simulatorCount)) {
+                                    throw IllegalArgumentException("WATCHOS.ALL cannot be used along with other WATCHOS targets")
+                                }
+                                containsAll = false
+                            }
+
                             maybeCreate(DARWIN_COMMON_MAIN).apply {
                                 dependsOn(getByName(NATIVE_COMMON_MAIN))
                                 dependsOn(getByName(UNIX_COMMON_MAIN))

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
@@ -19,6 +19,7 @@ package io.matthewnelson.components.kmp
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
 
 /**
  * Configures source sets for a Kotlin Multiplatform project in an opinionated fashion.
@@ -167,10 +168,10 @@ import org.gradle.api.Project
  *   JVM,
  *   JS,
  *   LINUX_ARM32HFP,LINUX_MIPS32,LINUX_MIPSEL32,LINUX_X64,
- *   IOS_ARM32,IOS_ARM64,IOS_X64,IOS_SIMULATOR_ARM64,
+ *   [ IOS_ALL **OR*** IOS_ARM32,IOS_ARM64,IOS_X64 ], **AND/OR** IOS_SIMULATOR_ARM64,
  *   MACOS_ARM64,MACOS_X64,
- *   TVOS_ARM64,TVOS_X64,TVOS_SIMULATOR_ARM64,
- *   WATCHOS_ARM32,WATCHOS_ARM64,WATCHOS_X64,WATCHOS_X86,WATCHOS_SIMULATOR_ARM64,
+ *   [ TVOS_ALL **OR** TVOS_ARM64,TVOS_X64 ], **AND/OR** TVOS_SIMULATOR_ARM64,
+ *   [ WATCHOS_ALL **OR** WATCHOS_ARM32,WATCHOS_ARM64,WATCHOS_X64,WATCHOS_X86], **AND/OR** WATCHOS_SIMULATOR_ARM64,
  *   MINGW_X64,MINGW_X86,
  *
  * Depending on the [KmpTarget]s passed, as well as what is enabled (as mentioned above),
@@ -222,6 +223,6 @@ import org.gradle.api.Project
 @Suppress("unused")
 class KmpConfigurationPlugin: Plugin<Project> {
     override fun apply(target: Project) {
-        target.extensions.create("kmpConfiguration", KmpConfigurationExtension::class.java, target)
+        target.extensions.create("kmpConfiguration", KmpConfigurationExtension::class, target)
     }
 }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
@@ -84,7 +84,7 @@ sealed class KmpTarget {
     }
 
     override fun toString(): String {
-        return "${this.javaClass.simpleName}()"
+        return "${this.javaClass.toString().split("$").takeLast(2).joinToString(".")}()"
     }
 
     sealed class JVM: KmpTarget() {
@@ -463,7 +463,7 @@ sealed class KmpTarget {
                         ) : IOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM32()
+                                val DEFAULT = IOS.ARM32()
 
                                 const val TARGET_NAME: String = "iosArm32"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -495,7 +495,7 @@ sealed class KmpTarget {
                         ) : IOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = IOS.ARM64()
 
                                 const val TARGET_NAME: String = "iosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -527,7 +527,7 @@ sealed class KmpTarget {
                         ) : IOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = X64()
+                                val DEFAULT = IOS.X64()
 
                                 const val TARGET_NAME: String = "iosX64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -627,7 +627,7 @@ sealed class KmpTarget {
                         ) : MACOS(), TargetCallback<KotlinNativeTargetWithHostTests> {
 
                              companion object {
-                                 val DEFAULT = X64()
+                                 val DEFAULT = MACOS.X64()
 
                                  const val TARGET_NAME: String = "macosX64"
                                  const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -695,7 +695,7 @@ sealed class KmpTarget {
                         ) : TVOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = TVOS.ARM64()
 
                                 const val TARGET_NAME: String = "tvosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -727,7 +727,7 @@ sealed class KmpTarget {
                         ) : TVOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = X64()
+                                val DEFAULT = TVOS.X64()
 
                                 const val TARGET_NAME: String = "tvosX64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -827,7 +827,7 @@ sealed class KmpTarget {
                         ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM32()
+                                val DEFAULT = WATCHOS.ARM32()
 
                                 const val TARGET_NAME: String = "watchosArm32"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -859,7 +859,7 @@ sealed class KmpTarget {
                         ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = WATCHOS.ARM64()
 
                                 const val TARGET_NAME: String = "watchosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -891,7 +891,7 @@ sealed class KmpTarget {
                         ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = X64()
+                                val DEFAULT = WATCHOS.X64()
 
                                 const val TARGET_NAME: String = "watchosX64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -923,7 +923,7 @@ sealed class KmpTarget {
                         ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = X86()
+                                val DEFAULT = WATCHOS.X86()
 
                                 const val TARGET_NAME: String = "watchosX86"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1014,7 +1014,7 @@ sealed class KmpTarget {
                     ) : LINUX(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = ARM32HFP()
+                            val DEFAULT = LINUX.ARM32HFP()
 
                             const val TARGET_NAME: String = "linuxArm32Hfp"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1046,7 +1046,7 @@ sealed class KmpTarget {
                     ) : LINUX(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = MIPS32()
+                            val DEFAULT = LINUX.MIPS32()
 
                             const val TARGET_NAME: String = "linuxMips32"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1078,7 +1078,7 @@ sealed class KmpTarget {
                     ) : LINUX(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = MIPSEL32()
+                            val DEFAULT = LINUX.MIPSEL32()
 
                             const val TARGET_NAME: String = "linuxMipsel32"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1110,7 +1110,7 @@ sealed class KmpTarget {
                     ) : LINUX(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = X64()
+                            val DEFAULT = LINUX.X64()
 
                             const val TARGET_NAME: String = "linuxX64"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1170,7 +1170,7 @@ sealed class KmpTarget {
                 ) : MINGW(), TargetCallback<KotlinNativeTargetWithHostTests> {
 
                     companion object {
-                        val DEFAULT = X64()
+                        val DEFAULT = MINGW.X64()
 
                         const val TARGET_NAME: String = "mingwX64"
                         const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1202,7 +1202,7 @@ sealed class KmpTarget {
                 ) : MINGW(), TargetCallback<KotlinNativeTarget> {
 
                     companion object {
-                        val DEFAULT = X86()
+                        val DEFAULT = MINGW.X86()
 
                         const val TARGET_NAME: String = "mingwX86"
                         const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.JavaVersion
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
@@ -210,7 +211,7 @@ sealed class KmpTarget {
             override fun setupMultiplatform(project: Project) {
                 applyPlugins(project)
                 project.kotlin {
-                    android(TARGET_NAME) target@{
+                    android(TARGET_NAME) target@ {
 
                         target?.invoke(this@target)
 
@@ -222,7 +223,7 @@ sealed class KmpTarget {
                     setupJvmSourceSets(project)
                 }
 
-                project.extensions.configure(BaseExtension::class.java) config@ {
+                project.extensions.configure(BaseExtension::class) config@ {
                     compileSdkVersion(this@ANDROID.compileSdk)
                     buildToolsVersion(this@ANDROID.buildTools)
 
@@ -421,6 +422,38 @@ sealed class KmpTarget {
                     }
 
                     sealed class IOS : DARWIN() {
+
+                        class ALL(
+                            override val pluginIds: Set<String>? = null,
+                            override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                            override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                        ): IOS(), TargetCallback<KotlinNativeTarget> {
+
+                            companion object {
+                                val DEFAULT = IOS.ALL()
+
+                                const val TARGET_NAME: String = "ios"
+                                const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
+                                const val SOURCE_SET_TEST_NAME: String = "$TARGET_NAME$TEST"
+                                const val ENV_PROPERTY_VALUE: String = "IOS_ALL"
+                            }
+
+                            override val sourceSetMainName: String get() = SOURCE_SET_MAIN_NAME
+                            override val sourceSetTestName: String get() = SOURCE_SET_TEST_NAME
+                            override val envPropertyValue: String get() = ENV_PROPERTY_VALUE
+
+                            override fun setupMultiplatform(project: Project) {
+                                applyPlugins(project)
+                                project.kotlin {
+                                    ios(TARGET_NAME) target@ {
+                                        target?.invoke(this@target)
+                                    }
+
+                                    setupDarwinSourceSets(project)
+                                }
+                            }
+                        }
 
                         class ARM32(
                             override val pluginIds: Set<String>? = null,
@@ -622,6 +655,38 @@ sealed class KmpTarget {
 
                     sealed class TVOS : DARWIN() {
 
+                        class ALL(
+                            override val pluginIds: Set<String>? = null,
+                            override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                            override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                        ) : TVOS(), TargetCallback<KotlinNativeTarget> {
+
+                            companion object {
+                                val DEFAULT = TVOS.ALL()
+
+                                const val TARGET_NAME: String = "tvos"
+                                const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
+                                const val SOURCE_SET_TEST_NAME: String = "$TARGET_NAME$TEST"
+                                const val ENV_PROPERTY_VALUE: String = "TVOS_ALL"
+                            }
+
+                            override val sourceSetMainName: String get() = SOURCE_SET_MAIN_NAME
+                            override val sourceSetTestName: String get() = SOURCE_SET_TEST_NAME
+                            override val envPropertyValue: String get() = ENV_PROPERTY_VALUE
+
+                            override fun setupMultiplatform(project: Project) {
+                                applyPlugins(project)
+                                project.kotlin {
+                                    tvos(TARGET_NAME) target@ {
+                                        target?.invoke(this@target)
+                                    }
+
+                                    setupDarwinSourceSets(project)
+                                }
+                            }
+                        }
+
                         class ARM64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
@@ -721,6 +786,38 @@ sealed class KmpTarget {
                     }
 
                     sealed class WATCHOS : DARWIN() {
+
+                        class ALL(
+                            override val pluginIds: Set<String>? = null,
+                            override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                            override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+
+                            companion object {
+                                val DEFAULT = WATCHOS.ALL()
+
+                                const val TARGET_NAME: String = "watchos"
+                                const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
+                                const val SOURCE_SET_TEST_NAME: String = "$TARGET_NAME$TEST"
+                                const val ENV_PROPERTY_VALUE: String = "WATCHOS_ALL"
+                            }
+
+                            override val sourceSetMainName: String get() = SOURCE_SET_MAIN_NAME
+                            override val sourceSetTestName: String get() = SOURCE_SET_TEST_NAME
+                            override val envPropertyValue: String get() = ENV_PROPERTY_VALUE
+
+                            override fun setupMultiplatform(project: Project) {
+                                applyPlugins(project)
+                                project.kotlin {
+                                    watchos(TARGET_NAME) target@ {
+                                        target?.invoke(this@target)
+                                    }
+
+                                    setupDarwinSourceSets(project)
+                                }
+                            }
+                        }
 
                         class ARM32(
                             override val pluginIds: Set<String>? = null,


### PR DESCRIPTION
 - Fixes KMP Targets `toString` override which was interfering with `kotlin.Set` being passed to `kmpConfigure` plugin extension method.
 - Bumps dependencies
 - Adds "shortcut" KmpTargets for `ios`, `tvos`, and `watchos`