### PR TITLE
Refactors KmpTargets

### DIFF
--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
@@ -15,22 +15,22 @@
  * */
 package io.matthewnelson.kotlin.components.kmp
 
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.Companion.COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.Companion.COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.JVM.Companion.JVM_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.JVM.Companion.JVM_COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.Companion.NON_JVM_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.Companion.NON_JVM_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.Companion.NATIVE_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.Companion.NATIVE_COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.MINGW.Companion.MINGW_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.MINGW.Companion.MINGW_COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.Companion.UNIX_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.Companion.UNIX_COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.Companion.DARWIN_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.Companion.DARWIN_COMMON_TEST
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.Companion.LINUX_COMMON_MAIN
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.Companion.LINUX_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.SetNames.COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.SetNames.COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.Jvm.Companion.JVM_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.Jvm.Companion.JVM_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Companion.NON_JVM_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Companion.NON_JVM_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Companion.NATIVE_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Companion.NATIVE_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Mingw.Companion.MINGW_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Mingw.Companion.MINGW_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Companion.UNIX_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Companion.UNIX_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Darwin.Companion.DARWIN_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Darwin.Companion.DARWIN_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Linux.Companion.LINUX_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Linux.Companion.LINUX_COMMON_TEST
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -45,43 +45,43 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
 
         private val ALL_ENV_PROPERTY_TARGETS: Set<String> = setOf(
             // jvm
-            KmpTarget.JVM.JVM.ENV_PROPERTY_VALUE,
-            KmpTarget.JVM.ANDROID.ENV_PROPERTY_VALUE,
+            KmpTarget.Jvm.Jvm.ENV_PROPERTY_VALUE,
+            KmpTarget.Jvm.Android.ENV_PROPERTY_VALUE,
 
             // js
-            KmpTarget.NON_JVM.JS.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.JS.ENV_PROPERTY_VALUE,
 
             // darwin
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ALL.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM32.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.X64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.SIMULATOR_ARM64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.All.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.ENV_PROPERTY_VALUE,
 
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.MACOS.X64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.MACOS.ARM64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.ENV_PROPERTY_VALUE,
 
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.ALL.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.ARM64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.X64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.TVOS.SIMULATOR_ARM64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.All.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.ENV_PROPERTY_VALUE,
 
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ALL.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ARM32.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.ARM64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.X64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.X86.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.WATCHOS.SIMULATOR_ARM64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.All.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.ENV_PROPERTY_VALUE,
 
             // linux
-            KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.ARM32HFP.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.MIPS32.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.MIPSEL32.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.UNIX.LINUX.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Linux.Arm32Hfp.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Linux.Mips32.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Linux.Mipsel32.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Unix.Linux.X64.ENV_PROPERTY_VALUE,
 
             // mingw
-            KmpTarget.NON_JVM.NATIVE.MINGW.X64.ENV_PROPERTY_VALUE,
-            KmpTarget.NON_JVM.NATIVE.MINGW.X86.ENV_PROPERTY_VALUE
+            KmpTarget.NonJvm.Native.Mingw.X64.ENV_PROPERTY_VALUE,
+            KmpTarget.NonJvm.Native.Mingw.X86.ENV_PROPERTY_VALUE
         )
     }
 
@@ -99,9 +99,9 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
         val enabledEnvironmentTargets: Set<String> = getEnabledEnvironmentTargets(project)
         val enabledTargets: List<KmpTarget> = targets.filter { enabledEnvironmentTargets.contains(it.envPropertyValue) }
 
-        var android: KmpTarget.JVM.ANDROID? = null
+        var android: KmpTarget.Jvm.Android? = null
         for (target in enabledTargets) {
-            if (target is KmpTarget.JVM.ANDROID) {
+            if (target is KmpTarget.Jvm.Android) {
                 android = target
                 break
             }
@@ -124,7 +124,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
         android?.setupMultiplatform(project)
 
         for (target in enabledTargets) {
-            if (target !is KmpTarget.JVM.ANDROID) {
+            if (target !is KmpTarget.Jvm.Android) {
                 target.setupMultiplatform(project)
             }
         }
@@ -155,7 +155,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     commonTestSourceSet?.invoke(this@sourceSetTest)
                 }
 
-                val jvmTargets = enabledTargets.filterIsInstance<KmpTarget.JVM>()
+                val jvmTargets = enabledTargets.filterIsInstance<KmpTarget.Jvm>()
                 if (jvmTargets.isNotEmpty()) {
                     maybeCreate(JVM_COMMON_MAIN).apply {
                         dependsOn(getByName(COMMON_MAIN))
@@ -165,8 +165,8 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     }
                 }
 
-                val jsTargets = enabledTargets.filterIsInstance<KmpTarget.NON_JVM.JS>()
-                val nativeTargets = enabledTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE>()
+                val jsTargets = enabledTargets.filterIsInstance<KmpTarget.NonJvm.JS>()
+                val nativeTargets = enabledTargets.filterIsInstance<KmpTarget.NonJvm.Native>()
 
                 if (jsTargets.isNotEmpty() || nativeTargets.isNotEmpty()) {
                     maybeCreate(NON_JVM_MAIN).apply {
@@ -185,7 +185,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                         dependsOn(getByName(NON_JVM_TEST))
                     }
 
-                    val unixTargets = nativeTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX>()
+                    val unixTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix>()
                     if (unixTargets.isNotEmpty()) {
                         maybeCreate(UNIX_COMMON_MAIN).apply {
                             dependsOn(getByName(NATIVE_COMMON_MAIN))
@@ -194,7 +194,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                             dependsOn(getByName(NATIVE_COMMON_TEST))
                         }
 
-                        val darwinTargets = unixTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN>()
+                        val darwinTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Darwin>()
                         if (darwinTargets.isNotEmpty()) {
                             maybeCreate(DARWIN_COMMON_MAIN).apply {
                                 dependsOn(getByName(NATIVE_COMMON_MAIN))
@@ -206,7 +206,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                             }
                         }
 
-                        val linuxTargets = unixTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.UNIX.LINUX>()
+                        val linuxTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Linux>()
                         if (linuxTargets.isNotEmpty()) {
                             maybeCreate(LINUX_COMMON_MAIN).apply {
                                 dependsOn(getByName(NATIVE_COMMON_MAIN))
@@ -219,7 +219,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                         }
                     }
 
-                    val mingwTargets = nativeTargets.filterIsInstance<KmpTarget.NON_JVM.NATIVE.MINGW>()
+                    val mingwTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Mingw>()
                     if (mingwTargets.isNotEmpty()) {
                         maybeCreate(MINGW_COMMON_MAIN).apply {
                             dependsOn(getByName(NATIVE_COMMON_MAIN))

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationPlugin.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationPlugin.kt
@@ -45,7 +45,7 @@ import org.gradle.kotlin.dsl.create
  *     setupMultiplatform(
  *         setOf(
  *             // list all kmp targets that the module will utilize
- *             KmpTarget.ANDROID(
+ *             KmpTarget.Jvm.Android(
  *                 buildTools = "30.0.3",
  *                 compileSdk = 30,
  *                 minSdk = 16,
@@ -84,7 +84,7 @@ import org.gradle.kotlin.dsl.create
  *                 },
  *
  *             ),
- *             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM32(
+ *             KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32(
  *                 target = {
  *                     ...
  *                 },
@@ -96,7 +96,7 @@ import org.gradle.kotlin.dsl.create
  *             ),
  *
  *             // Optionally, utilize the `DEFAULT`s provided (no callbacks)
- *             KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.IOS.ARM64.DEFAULT,
+ *             KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
  *             ...
  *         ),
  *
@@ -118,7 +118,7 @@ import org.gradle.kotlin.dsl.create
  * }
  * ```
  *
- * Alternatively, import the [io.matthewnelson.components.kmp.kotlin] extension function
+ * Alternatively, import the [io.matthewnelson.kotlin.components.kmp.kotlin] extension function
  * and configure things further after the `kmpConfiguration` block.
  *
  * ```
@@ -135,19 +135,19 @@ import org.gradle.kotlin.dsl.create
  *
  * kotlin {
  *     sourceSets {
- *         getByName(KmpTarget.COMMON_MAIN) {
+ *         getByName(KmpTarget.SetNames.COMMON_MAIN) {
  *             dependencies {
  *                 implementation(project(":my-other-project-module"))
  *             }
  *         }
- *         getByName(KmpTarget.NON_JVM.NATIVE.UNIX.DARWIN.MACOS.X64.SOURCE_SET_MAIN_NAME) {
+ *         getByName(KmpTarget.SetNames.MACOS_X64_MAIN) {
  *             dependencies {
  *                 implementation(project(":my-other-macos-only-project"))
  *             }
  *         }
  *     }
  *
- *     targets.getByName(KmpTarget.NON_JVM.JS.TARGET_NAME) {
+ *     targets.getByName(KmpTarget.NonJvm.JS.TARGET_NAME) {
  *         ...
  *     }
  * }
@@ -168,10 +168,10 @@ import org.gradle.kotlin.dsl.create
  *   JVM,
  *   JS,
  *   LINUX_ARM32HFP,LINUX_MIPS32,LINUX_MIPSEL32,LINUX_X64,
- *   [ IOS_ALL **OR*** IOS_ARM32,IOS_ARM64,IOS_X64 ], **AND/OR** IOS_SIMULATOR_ARM64,
+ *   IOS_ALL,IOS_ARM32,IOS_ARM64,IOS_X64,IOS_SIMULATOR_ARM64,
  *   MACOS_ARM64,MACOS_X64,
- *   [ TVOS_ALL **OR** TVOS_ARM64,TVOS_X64 ], **AND/OR** TVOS_SIMULATOR_ARM64,
- *   [ WATCHOS_ALL **OR** WATCHOS_ARM32,WATCHOS_ARM64,WATCHOS_X64,WATCHOS_X86], **AND/OR** WATCHOS_SIMULATOR_ARM64,
+ *   TVOS_ALL,TVOS_ARM64,TVOS_X64,TVOS_SIMULATOR_ARM64,
+ *   WATCHOS_ALL,WATCHOS_ARM32,WATCHOS_ARM64,WATCHOS_X64,WATCHOS_X86,WATCHOS_SIMULATOR_ARM64,
  *   MINGW_X64,MINGW_X86,
  *
  * Depending on the [KmpTarget]s passed, as well as what is enabled (as mentioned above),
@@ -199,7 +199,6 @@ import org.gradle.kotlin.dsl.create
  *                  |       |        |-- watchosArm32
  *                  |       |        |-- watchosArm64
  *                  |       |        |-- watchosX64
- *                  |       |        |-- watchosX64
  *                  |       |        '-- watchosSimulatorArm64
  *                  |       '-- linuxCommon
  *                  |                |-- linuxArm32Hfp
@@ -223,6 +222,6 @@ import org.gradle.kotlin.dsl.create
 @Suppress("unused")
 class KmpConfigurationPlugin: Plugin<Project> {
     override fun apply(target: Project) {
-        target.extensions.create("kmpConfiguration", KmpConfigurationExtension::class, target)
+        target.extensions.create<KmpConfigurationExtension>("kmpConfiguration", target)
     }
 }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
@@ -39,11 +39,95 @@ import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 sealed class KmpTarget {
 
     companion object {
-        const val COMMON_MAIN = KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME
-        const val COMMON_TEST = KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME
-
         private const val MAIN = "Main"
         private const val TEST = "Test"
+    }
+
+    object SetNames {
+
+        val COMMON_MAIN get() = KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME
+        val COMMON_TEST get() = KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME
+
+        val JVM_COMMON_MAIN get() = Jvm.JVM_COMMON_MAIN
+        val JVM_COMMON_TEST get() = Jvm.JVM_COMMON_TEST
+
+        val JVM_MAIN get() = Jvm.Jvm.SOURCE_SET_MAIN_NAME
+        val JVM_TEST get() = Jvm.Jvm.SOURCE_SET_TEST_NAME
+
+        val ANDROID_MAIN get() = Jvm.Android.SOURCE_SET_MAIN_NAME
+        val ANDROID_TEST get() = Jvm.Android.SOURCE_SET_TEST_NAME
+
+        val NON_JVM_MAIN get() = NonJvm.NON_JVM_MAIN
+        val NON_JVM_TEST get() = NonJvm.NON_JVM_TEST
+
+        val JS_MAIN get() = NonJvm.JS.SOURCE_SET_MAIN_NAME
+        val JS_TEST get() = NonJvm.JS.SOURCE_SET_TEST_NAME
+
+        val NATIVE_COMMON_MAIN get() = NonJvm.Native.NATIVE_COMMON_MAIN
+        val NATIVE_COMMON_TEST get() = NonJvm.Native.NATIVE_COMMON_TEST
+
+        val UNIX_COMMON_MAIN get() = NonJvm.Native.Unix.UNIX_COMMON_MAIN
+        val UNIX_COMMON_TEST get() = NonJvm.Native.Unix.UNIX_COMMON_TEST
+
+        val DARWIN_COMMON_MAIN get() = NonJvm.Native.Unix.Darwin.DARWIN_COMMON_MAIN
+        val DARWIN_COMMON_TEST get() = NonJvm.Native.Unix.Darwin.DARWIN_COMMON_TEST
+
+        val IOS_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.All.SOURCE_SET_MAIN_NAME
+        val IOS_TEST get() = NonJvm.Native.Unix.Darwin.Ios.All.SOURCE_SET_TEST_NAME
+        val IOS_ARM32_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.Arm32.SOURCE_SET_MAIN_NAME
+        val IOS_ARM32_TEST get() = NonJvm.Native.Unix.Darwin.Ios.Arm32.SOURCE_SET_TEST_NAME
+        val IOS_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.Arm64.SOURCE_SET_MAIN_NAME
+        val IOS_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Ios.Arm64.SOURCE_SET_TEST_NAME
+        val IOS_X64_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.X64.SOURCE_SET_MAIN_NAME
+        val IOS_X64_TEST get() = NonJvm.Native.Unix.Darwin.Ios.X64.SOURCE_SET_TEST_NAME
+        val IOS_SIMULATOR_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.SOURCE_SET_MAIN_NAME
+        val IOS_SIMULATOR_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.SOURCE_SET_TEST_NAME
+
+        val MACOS_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Macos.Arm64.SOURCE_SET_MAIN_NAME
+        val MACOS_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Macos.Arm64.SOURCE_SET_TEST_NAME
+        val MACOS_X64_MAIN get() = NonJvm.Native.Unix.Darwin.Macos.X64.SOURCE_SET_MAIN_NAME
+        val MACOS_X64_TEST get() = NonJvm.Native.Unix.Darwin.Macos.X64.SOURCE_SET_TEST_NAME
+
+        val TVOS_MAIN get() = NonJvm.Native.Unix.Darwin.Tvos.All.SOURCE_SET_MAIN_NAME
+        val TVOS_TEST get() = NonJvm.Native.Unix.Darwin.Tvos.All.SOURCE_SET_TEST_NAME
+        val TVOS_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Tvos.Arm64.SOURCE_SET_MAIN_NAME
+        val TVOS_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Tvos.Arm64.SOURCE_SET_TEST_NAME
+        val TVOS_X64_MAIN get() = NonJvm.Native.Unix.Darwin.Tvos.X64.SOURCE_SET_MAIN_NAME
+        val TVOS_X64_TEST get() = NonJvm.Native.Unix.Darwin.Tvos.X64.SOURCE_SET_TEST_NAME
+        val TVOS_SIMULATOR_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.SOURCE_SET_MAIN_NAME
+        val TVOS_SIMULATOR_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.SOURCE_SET_TEST_NAME
+
+        val WATCHOS_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.All.SOURCE_SET_MAIN_NAME
+        val WATCHOS_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.All.SOURCE_SET_TEST_NAME
+        val WATCHOS_ARM32_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.Arm32.SOURCE_SET_MAIN_NAME
+        val WATCHOS_ARM32_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.Arm32.SOURCE_SET_TEST_NAME
+        val WATCHOS_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.Arm64.SOURCE_SET_MAIN_NAME
+        val WATCHOS_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.Arm64.SOURCE_SET_TEST_NAME
+        val WATCHOS_X64_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.X64.SOURCE_SET_MAIN_NAME
+        val WATCHOS_X64_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.X64.SOURCE_SET_TEST_NAME
+        val WATCHOS_X86_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.X86.SOURCE_SET_MAIN_NAME
+        val WATCHOS_X86_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.X86.SOURCE_SET_TEST_NAME
+        val WATCHOS_SIMULATOR_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.SOURCE_SET_MAIN_NAME
+        val WATCHOS_SIMULATOR_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.SOURCE_SET_TEST_NAME
+
+        val LINUX_COMMON_MAIN get() = NonJvm.Native.Unix.Linux.LINUX_COMMON_MAIN
+        val LINUX_COMMON_TEST get() = NonJvm.Native.Unix.Linux.LINUX_COMMON_TEST
+        val LINUX_ARM32HFP_MAIN get() = NonJvm.Native.Unix.Linux.Arm32Hfp.SOURCE_SET_MAIN_NAME
+        val LINUX_ARM32HFP_TEST get() = NonJvm.Native.Unix.Linux.Arm32Hfp.SOURCE_SET_TEST_NAME
+        val LINUX_MIPS32_MAIN get() = NonJvm.Native.Unix.Linux.Mips32.SOURCE_SET_MAIN_NAME
+        val LINUX_MIPS32_TEST get() = NonJvm.Native.Unix.Linux.Mips32.SOURCE_SET_TEST_NAME
+        val LINUX_MIPSEL32_MAIN get() = NonJvm.Native.Unix.Linux.Mipsel32.SOURCE_SET_MAIN_NAME
+        val LINUX_MIPSEL32_TEST get() = NonJvm.Native.Unix.Linux.Mipsel32.SOURCE_SET_TEST_NAME
+        val LINUX_X64_MAIN get() = NonJvm.Native.Unix.Linux.X64.SOURCE_SET_MAIN_NAME
+        val LINUX_X64_TEST get() = NonJvm.Native.Unix.Linux.X64.SOURCE_SET_TEST_NAME
+
+        val MINGW_COMMON_MAIN get() = NonJvm.Native.Mingw.MINGW_COMMON_MAIN
+        val MINGW_COMMON_TEST get() = NonJvm.Native.Mingw.MINGW_COMMON_TEST
+        val MINGW_X64_MAIN get() = NonJvm.Native.Mingw.X64.SOURCE_SET_MAIN_NAME
+        val MINGW_X64_TEST get() = NonJvm.Native.Mingw.X64.SOURCE_SET_TEST_NAME
+        val MINGW_X86_MAIN get() = NonJvm.Native.Mingw.X86.SOURCE_SET_MAIN_NAME
+        val MINGW_X86_TEST get() = NonJvm.Native.Mingw.X86.SOURCE_SET_TEST_NAME
+
     }
 
     protected abstract val mainSourceSet: (KotlinSourceSet.() -> Unit)?
@@ -87,7 +171,7 @@ sealed class KmpTarget {
         return "${this.javaClass.toString().split("$").takeLast(2).joinToString(".")}()"
     }
 
-    sealed class JVM: KmpTarget() {
+    sealed class Jvm: KmpTarget() {
 
         companion object {
             const val JVM_COMMON_MAIN = "jvmCommon$MAIN"
@@ -105,7 +189,7 @@ sealed class KmpTarget {
                     maybeCreate(sourceSetTestName).apply testSourceSet@ {
                         dependsOn(getByName(JVM_COMMON_TEST))
 
-                        if (this@JVM is ANDROID) {
+                        if (this@Jvm is Android) {
                             dependsOn(getByName("androidAndroidTestRelease"))
                         }
 
@@ -115,15 +199,15 @@ sealed class KmpTarget {
             }
         }
 
-        class JVM(
+        class Jvm(
             override val pluginIds: Set<String>? = null,
             override val target: (KotlinJvmTarget.() -> Unit)? = null,
             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-        ) : KmpTarget.JVM(), TargetCallback<KotlinJvmTarget> {
+        ) : KmpTarget.Jvm(), TargetCallback<KotlinJvmTarget> {
 
             companion object {
-                val DEFAULT: JVM = JVM()
+                val DEFAULT: Jvm = Jvm()
 
                 const val TARGET_NAME: String = "jvm"
                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -147,7 +231,7 @@ sealed class KmpTarget {
             }
         }
 
-        class ANDROID(
+        class Android(
             private val compileSdk: Int,
             private val minSdk: Int,
             manifestPath: String,
@@ -161,7 +245,7 @@ sealed class KmpTarget {
             override val target: (KotlinAndroidTarget.() -> Unit)? = null,
             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-        ) : KmpTarget.JVM(), TargetCallback<KotlinAndroidTarget> {
+        ) : KmpTarget.Jvm(), TargetCallback<KotlinAndroidTarget> {
 
             companion object {
                 const val TARGET_NAME: String = "android"
@@ -230,14 +314,14 @@ sealed class KmpTarget {
                 }
 
                 project.extensions.configure(BaseExtension::class) config@ {
-                    compileSdkVersion(this@ANDROID.compileSdk)
-                    this@ANDROID.buildTools?.let { buildToolsVersion = it }
+                    compileSdkVersion(this@Android.compileSdk)
+                    this@Android.buildTools?.let { buildToolsVersion = it }
 
-                    this@ANDROID.manifestPath?.let { path -> sourceSets.getByName("main").manifest.srcFile(path) }
+                    this@Android.manifestPath?.let { path -> sourceSets.getByName("main").manifest.srcFile(path) }
 
                     defaultConfig {
-                        minSdk = this@ANDROID.minSdk
-                        this@ANDROID.targetSdk?.let { targetSdk = it }
+                        minSdk = this@Android.minSdk
+                        this@Android.targetSdk?.let { targetSdk = it }
 
                         testInstrumentationRunnerArguments["disableAnalytics"] = "true"
                     }
@@ -265,7 +349,7 @@ sealed class KmpTarget {
 
     }
 
-    sealed class NON_JVM: KmpTarget() {
+    sealed class NonJvm: KmpTarget() {
 
         companion object {
             const val NON_JVM_MAIN = "nonJvmMain"
@@ -279,7 +363,7 @@ sealed class KmpTarget {
             override val pluginIds: Set<String>? = null,
             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-        ) : NON_JVM() {
+        ) : NonJvm() {
 
             class Browser(val jsBrowserDsl: (KotlinJsBrowserDsl.() -> Unit)? = null) {
                 override fun toString(): String {
@@ -389,21 +473,21 @@ sealed class KmpTarget {
 
         }
 
-        sealed class NATIVE: NON_JVM() {
+        sealed class Native: NonJvm() {
 
             companion object {
                 const val NATIVE_COMMON_MAIN = "nativeCommon$MAIN"
                 const val NATIVE_COMMON_TEST = "nativeCommon$TEST"
             }
 
-            sealed class UNIX: NATIVE() {
+            sealed class Unix: Native() {
 
                 companion object {
                     const val UNIX_COMMON_MAIN = "unixCommon$MAIN"
                     const val UNIX_COMMON_TEST = "unixCommon$TEST"
                 }
 
-                sealed class DARWIN: UNIX() {
+                sealed class Darwin: Unix() {
 
                     companion object {
                         const val DARWIN_COMMON_MAIN = "darwinCommon$MAIN"
@@ -427,17 +511,17 @@ sealed class KmpTarget {
                         }
                     }
 
-                    sealed class IOS : DARWIN() {
+                    sealed class Ios : Darwin() {
 
-                        class ALL(
+                        class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ): IOS(), TargetCallback<KotlinNativeTarget> {
+                        ): Ios(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ALL()
+                                val DEFAULT = All()
 
                                 const val TARGET_NAME: String = "ios"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -461,15 +545,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class ARM32(
+                        class Arm32(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : IOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Ios(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM32()
+                                val DEFAULT = Arm32()
 
                                 const val TARGET_NAME: String = "iosArm32"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -493,15 +577,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class ARM64(
+                        class Arm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: ((KotlinSourceSet) -> Unit)? = null,
                             override val testSourceSet: ((KotlinSourceSet) -> Unit)? = null
-                        ) : IOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Ios(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = Arm64()
 
                                 const val TARGET_NAME: String = "iosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -530,7 +614,7 @@ sealed class KmpTarget {
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : IOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Ios(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
                                 val DEFAULT = X64()
@@ -557,15 +641,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class SIMULATOR_ARM64(
+                        class SimulatorArm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : IOS(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
+                        ) : Ios(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
 
                             companion object {
-                                val DEFAULT = SIMULATOR_ARM64()
+                                val DEFAULT = SimulatorArm64()
 
                                 const val TARGET_NAME: String = "iosSimulatorArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -591,17 +675,17 @@ sealed class KmpTarget {
 
                     }
 
-                    sealed class MACOS : DARWIN() {
+                    sealed class Macos : Darwin() {
 
-                        class ARM64(
+                        class Arm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTargetWithHostTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : MACOS(), TargetCallback<KotlinNativeTargetWithHostTests> {
+                        ) : Macos(), TargetCallback<KotlinNativeTargetWithHostTests> {
 
                              companion object {
-                                 val DEFAULT = ARM64()
+                                 val DEFAULT = Arm64()
 
                                  const val TARGET_NAME: String = "macosArm64"
                                  const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -630,7 +714,7 @@ sealed class KmpTarget {
                             override val target: (KotlinNativeTargetWithHostTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : MACOS(), TargetCallback<KotlinNativeTargetWithHostTests> {
+                        ) : Macos(), TargetCallback<KotlinNativeTargetWithHostTests> {
 
                              companion object {
                                  val DEFAULT = X64()
@@ -659,17 +743,17 @@ sealed class KmpTarget {
 
                     }
 
-                    sealed class TVOS : DARWIN() {
+                    sealed class Tvos : Darwin() {
 
-                        class ALL(
+                        class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : TVOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Tvos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ALL()
+                                val DEFAULT = All()
 
                                 const val TARGET_NAME: String = "tvos"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -693,15 +777,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class ARM64(
+                        class Arm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : TVOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Tvos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = Arm64()
 
                                 const val TARGET_NAME: String = "tvosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -730,7 +814,7 @@ sealed class KmpTarget {
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : TVOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Tvos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
                                 val DEFAULT = X64()
@@ -757,15 +841,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class SIMULATOR_ARM64(
+                        class SimulatorArm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : TVOS(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
+                        ) : Tvos(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
 
                             companion object {
-                                val DEFAULT = SIMULATOR_ARM64()
+                                val DEFAULT = SimulatorArm64()
 
                                 const val TARGET_NAME: String = "tvosSimulatorArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -791,17 +875,17 @@ sealed class KmpTarget {
 
                     }
 
-                    sealed class WATCHOS : DARWIN() {
+                    sealed class Watchos : Darwin() {
 
-                        class ALL(
+                        class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ALL()
+                                val DEFAULT = All()
 
                                 const val TARGET_NAME: String = "watchos"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -825,15 +909,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class ARM32(
+                        class Arm32(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM32()
+                                val DEFAULT = Arm32()
 
                                 const val TARGET_NAME: String = "watchosArm32"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -857,15 +941,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class ARM64(
+                        class Arm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
-                                val DEFAULT = ARM64()
+                                val DEFAULT = Arm64()
 
                                 const val TARGET_NAME: String = "watchosArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -894,7 +978,7 @@ sealed class KmpTarget {
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
                                 val DEFAULT = X64()
@@ -926,7 +1010,7 @@ sealed class KmpTarget {
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTarget> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTarget> {
 
                             companion object {
                                 val DEFAULT = X86()
@@ -953,15 +1037,15 @@ sealed class KmpTarget {
                             }
                         }
 
-                        class SIMULATOR_ARM64(
+                        class SimulatorArm64(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                        ) : WATCHOS(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
+                        ) : Watchos(), TargetCallback<KotlinNativeTargetWithSimulatorTests> {
 
                             companion object {
-                                val DEFAULT = SIMULATOR_ARM64()
+                                val DEFAULT = SimulatorArm64()
 
                                 const val TARGET_NAME: String = "watchosSimulatorArm64"
                                 const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -988,7 +1072,7 @@ sealed class KmpTarget {
                     }
                 }
 
-                sealed class LINUX : UNIX() {
+                sealed class Linux : Unix() {
 
                     companion object {
                         const val LINUX_COMMON_MAIN = "linuxCommon$MAIN"
@@ -1012,15 +1096,15 @@ sealed class KmpTarget {
                         }
                     }
 
-                    class ARM32HFP(
+                    class Arm32Hfp(
                         override val pluginIds: Set<String>? = null,
                         override val target: (KotlinNativeTarget.() -> Unit)? = null,
                         override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                         override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                    ) : LINUX(), TargetCallback<KotlinNativeTarget> {
+                    ) : Linux(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = ARM32HFP()
+                            val DEFAULT = Arm32Hfp()
 
                             const val TARGET_NAME: String = "linuxArm32Hfp"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1044,15 +1128,15 @@ sealed class KmpTarget {
                         }
                     }
 
-                    class MIPS32(
+                    class Mips32(
                         override val pluginIds: Set<String>? = null,
                         override val target: (KotlinNativeTarget.() -> Unit)? = null,
                         override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                         override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                    ) : LINUX(), TargetCallback<KotlinNativeTarget> {
+                    ) : Linux(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = MIPS32()
+                            val DEFAULT = Mips32()
 
                             const val TARGET_NAME: String = "linuxMips32"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1076,15 +1160,15 @@ sealed class KmpTarget {
                         }
                     }
 
-                    class MIPSEL32(
+                    class Mipsel32(
                         override val pluginIds: Set<String>? = null,
                         override val target: (KotlinNativeTarget.() -> Unit)? = null,
                         override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                         override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                    ) : LINUX(), TargetCallback<KotlinNativeTarget> {
+                    ) : Linux(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
-                            val DEFAULT = MIPSEL32()
+                            val DEFAULT = Mipsel32()
 
                             const val TARGET_NAME: String = "linuxMipsel32"
                             const val SOURCE_SET_MAIN_NAME: String = "$TARGET_NAME$MAIN"
@@ -1113,7 +1197,7 @@ sealed class KmpTarget {
                         override val target: (KotlinNativeTarget.() -> Unit)? = null,
                         override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                         override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
-                    ) : LINUX(), TargetCallback<KotlinNativeTarget> {
+                    ) : Linux(), TargetCallback<KotlinNativeTarget> {
 
                         companion object {
                             val DEFAULT = X64()
@@ -1144,7 +1228,7 @@ sealed class KmpTarget {
 
             }
 
-            sealed class MINGW : NATIVE() {
+            sealed class Mingw : Native() {
 
                 companion object {
                     const val MINGW_COMMON_MAIN = "mingwCommon$MAIN"
@@ -1173,7 +1257,7 @@ sealed class KmpTarget {
                     override val target: (KotlinNativeTargetWithHostTests.() -> Unit)? = null,
                     override val mainSourceSet: ((KotlinSourceSet) -> Unit)? = null,
                     override val testSourceSet: ((KotlinSourceSet) -> Unit)? = null
-                ) : MINGW(), TargetCallback<KotlinNativeTargetWithHostTests> {
+                ) : Mingw(), TargetCallback<KotlinNativeTargetWithHostTests> {
 
                     companion object {
                         val DEFAULT = X64()
@@ -1205,7 +1289,7 @@ sealed class KmpTarget {
                     override val target: (KotlinNativeTarget.() -> Unit)? = null,
                     override val mainSourceSet: ((KotlinSourceSet) -> Unit)? = null,
                     override val testSourceSet: ((KotlinSourceSet) -> Unit)? = null
-                ) : MINGW(), TargetCallback<KotlinNativeTarget> {
+                ) : Mingw(), TargetCallback<KotlinNativeTarget> {
 
                     companion object {
                         val DEFAULT = X86()

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
@@ -20,6 +20,7 @@ package io.matthewnelson.kotlin.components.kmp
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import com.android.build.gradle.BaseExtension
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64
 import org.gradle.api.JavaVersion
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.invoke
@@ -513,9 +514,20 @@ sealed class KmpTarget {
 
                     sealed class Ios : Darwin() {
 
+                        /**
+                         * To enable the [SimulatorArm64] target, set [enableSimulator] value.
+                         * It will create a new instance of [SimulatorArm64] and utilize your
+                         * already declared [mainSourceSet] and [testSourceSet] values.
+                         *
+                         * If you need something different for the Main and Test sourceSets as
+                         * they pertain to the SimulatorArm64 functionality, simply leave
+                         * [enableSimulator] null, and pass the additional [KmpTarget] in the
+                         * [Set] during configuration.
+                         * */
                         class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            private val enableSimulator: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
                         ): Ios(), TargetCallback<KotlinNativeTarget> {
@@ -541,6 +553,15 @@ sealed class KmpTarget {
                                     }
 
                                     setupDarwinSourceSets(project)
+                                }
+
+                                if (enableSimulator != null) {
+                                    SimulatorArm64(
+                                        pluginIds = null,
+                                        target = enableSimulator,
+                                        mainSourceSet = mainSourceSet,
+                                        testSourceSet = testSourceSet
+                                    ).setupMultiplatform(project)
                                 }
                             }
                         }
@@ -745,9 +766,20 @@ sealed class KmpTarget {
 
                     sealed class Tvos : Darwin() {
 
+                        /**
+                         * To enable the [SimulatorArm64] target, set [enableSimulator] value.
+                         * It will create a new instance of [SimulatorArm64] and utilize your
+                         * already declared [mainSourceSet] and [testSourceSet] values.
+                         *
+                         * If you need something different for the Main and Test sourceSets as
+                         * they pertain to the SimulatorArm64 functionality, simply leave
+                         * [enableSimulator] null, and pass the additional [KmpTarget] in the
+                         * [Set] during configuration.
+                         * */
                         class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            private val enableSimulator: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
                         ) : Tvos(), TargetCallback<KotlinNativeTarget> {
@@ -773,6 +805,15 @@ sealed class KmpTarget {
                                     }
 
                                     setupDarwinSourceSets(project)
+                                }
+
+                                if (enableSimulator != null) {
+                                    SimulatorArm64(
+                                        pluginIds = null,
+                                        target = enableSimulator,
+                                        mainSourceSet = mainSourceSet,
+                                        testSourceSet = testSourceSet
+                                    ).setupMultiplatform(project)
                                 }
                             }
                         }
@@ -877,9 +918,20 @@ sealed class KmpTarget {
 
                     sealed class Watchos : Darwin() {
 
+                        /**
+                         * To enable the [SimulatorArm64] target, set [enableSimulator] value.
+                         * It will create a new instance of [SimulatorArm64] and utilize your
+                         * already declared [mainSourceSet] and [testSourceSet] values.
+                         *
+                         * If you need something different for the Main and Test sourceSets as
+                         * they pertain to the SimulatorArm64 functionality, simply leave
+                         * [enableSimulator] null, and pass the additional [KmpTarget] in the
+                         * [Set] during configuration.
+                         * */
                         class All(
                             override val pluginIds: Set<String>? = null,
                             override val target: (KotlinNativeTarget.() -> Unit)? = null,
+                            private val enableSimulator: (KotlinNativeTargetWithSimulatorTests.() -> Unit)? = null,
                             override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
                             override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
                         ) : Watchos(), TargetCallback<KotlinNativeTarget> {
@@ -905,6 +957,15 @@ sealed class KmpTarget {
                                     }
 
                                     setupDarwinSourceSets(project)
+                                }
+
+                                if (enableSimulator != null) {
+                                    SimulatorArm64(
+                                        pluginIds = null,
+                                        target = enableSimulator,
+                                        mainSourceSet = mainSourceSet,
+                                        testSourceSet = testSourceSet
+                                    ).setupMultiplatform(project)
                                 }
                             }
                         }


### PR DESCRIPTION
- Decapitalizes KmpTarget class names
- Adds shortcuts to SourceSet names at `KmpTarget.SetNames`
- Adds ability to pass a lambda in the constructor of `Ios.All`, `Tvos.All`, and `Watchos.All` to enable Apple silicon simulator targets.