### PR TITLE
kmp-configuration plugin fixes

### DIFF
--- a/includeBuild/dependencies/build.gradle.kts
+++ b/includeBuild/dependencies/build.gradle.kts
@@ -10,6 +10,11 @@ repositories {
     gradlePluginPortal()
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 gradlePlugin {
     plugins.register("dependencies") {
         id = "dependencies"

--- a/includeBuild/kmp/build.gradle.kts
+++ b/includeBuild/kmp/build.gradle.kts
@@ -11,6 +11,11 @@ repositories {
     gradlePluginPortal()
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compileOnly(Plugins.android.gradle)
     compileOnly(Plugins.kotlin.gradle)

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
@@ -31,6 +31,8 @@ import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Darwi
 import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Darwin.Companion.DARWIN_COMMON_TEST
 import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Linux.Companion.LINUX_COMMON_MAIN
 import io.matthewnelson.kotlin.components.kmp.KmpTarget.NonJvm.Native.Unix.Linux.Companion.LINUX_COMMON_TEST
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.SetNames.MACOS_COMMON_MAIN
+import io.matthewnelson.kotlin.components.kmp.KmpTarget.SetNames.MACOS_COMMON_TEST
 import io.matthewnelson.kotlin.components.kmp.util.*
 import io.matthewnelson.kotlin.components.kmp.util.EnvProperty
 import org.gradle.api.Project
@@ -231,6 +233,22 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                                 dependsOn(getByName(NON_JVM_TEST))
                                 dependsOn(getByName(NATIVE_COMMON_TEST))
                                 dependsOn(getByName(UNIX_COMMON_TEST))
+                            }
+
+                            val macosTargets = darwinTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Darwin.Macos>()
+                            if (macosTargets.isNotEmpty()) {
+                                maybeCreate(MACOS_COMMON_MAIN).apply {
+                                    dependsOn(getByName(NON_JVM_MAIN))
+                                    dependsOn(getByName(NATIVE_COMMON_MAIN))
+                                    dependsOn(getByName(UNIX_COMMON_MAIN))
+                                    dependsOn(getByName(DARWIN_COMMON_MAIN))
+                                }
+                                maybeCreate(MACOS_COMMON_TEST).apply {
+                                    dependsOn(getByName(NON_JVM_TEST))
+                                    dependsOn(getByName(NATIVE_COMMON_TEST))
+                                    dependsOn(getByName(UNIX_COMMON_TEST))
+                                    dependsOn(getByName(DARWIN_COMMON_TEST))
+                                }
                             }
                         }
 

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
@@ -163,7 +163,16 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
     ) {
         project.kotlin {
             sourceSets {
+
+                val jvmTargets = enabledTargets.filterIsInstance<KmpTarget.Jvm<*>>()
+
                 getByName(COMMON_MAIN) sourceSetMain@ {
+                    if (jvmTargets.isEmpty()) {
+                        dependencies {
+                            // https://youtrack.jetbrains.com/issue/KT-40333
+                            implementation(kotlin("stdlib-common"))
+                        }
+                    }
                     commonMainSourceSet?.invoke(this@sourceSetMain)
                 }
 
@@ -171,7 +180,6 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     commonTestSourceSet?.invoke(this@sourceSetTest)
                 }
 
-                val jvmTargets = enabledTargets.filterIsInstance<KmpTarget.Jvm<*>>()
                 if (jvmTargets.isNotEmpty()) {
                     maybeCreate(JVM_COMMON_MAIN).apply {
                         dependsOn(getByName(COMMON_MAIN))

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
@@ -204,19 +204,23 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     val unixTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix<*>>()
                     if (unixTargets.isNotEmpty()) {
                         maybeCreate(UNIX_COMMON_MAIN).apply {
+                            dependsOn(getByName(NON_JVM_MAIN))
                             dependsOn(getByName(NATIVE_COMMON_MAIN))
                         }
                         maybeCreate(UNIX_COMMON_TEST).apply {
+                            dependsOn(getByName(NON_JVM_TEST))
                             dependsOn(getByName(NATIVE_COMMON_TEST))
                         }
 
                         val darwinTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Darwin<*>>()
                         if (darwinTargets.isNotEmpty()) {
                             maybeCreate(DARWIN_COMMON_MAIN).apply {
+                                dependsOn(getByName(NON_JVM_MAIN))
                                 dependsOn(getByName(NATIVE_COMMON_MAIN))
                                 dependsOn(getByName(UNIX_COMMON_MAIN))
                             }
                             maybeCreate(DARWIN_COMMON_TEST).apply {
+                                dependsOn(getByName(NON_JVM_TEST))
                                 dependsOn(getByName(NATIVE_COMMON_TEST))
                                 dependsOn(getByName(UNIX_COMMON_TEST))
                             }
@@ -225,10 +229,12 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                         val linuxTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Linux>()
                         if (linuxTargets.isNotEmpty()) {
                             maybeCreate(LINUX_COMMON_MAIN).apply {
+                                dependsOn(getByName(NON_JVM_MAIN))
                                 dependsOn(getByName(NATIVE_COMMON_MAIN))
                                 dependsOn(getByName(UNIX_COMMON_MAIN))
                             }
                             maybeCreate(LINUX_COMMON_TEST).apply {
+                                dependsOn(getByName(NON_JVM_TEST))
                                 dependsOn(getByName(NATIVE_COMMON_TEST))
                                 dependsOn(getByName(UNIX_COMMON_TEST))
                             }
@@ -238,9 +244,11 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     val mingwTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Mingw<*>>()
                     if (mingwTargets.isNotEmpty()) {
                         maybeCreate(MINGW_COMMON_MAIN).apply {
+                            dependsOn(getByName(NON_JVM_MAIN))
                             dependsOn(getByName(NATIVE_COMMON_MAIN))
                         }
                         maybeCreate(MINGW_COMMON_TEST).apply {
+                            dependsOn(getByName(NON_JVM_TEST))
                             dependsOn(getByName(NATIVE_COMMON_TEST))
                         }
                     }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
@@ -1312,8 +1312,8 @@ sealed class KmpTarget<T: KotlinTarget> {
                 class X64(
                     override val pluginIds: Set<String>? = null,
                     override val target: (KotlinNativeTargetWithHostTests.() -> Unit)? = null,
-                    override val mainSourceSet: ((KotlinSourceSet) -> Unit)? = null,
-                    override val testSourceSet: ((KotlinSourceSet) -> Unit)? = null
+                    override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                    override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
                 ) : Mingw<KotlinNativeTargetWithHostTests>() {
 
                     companion object {
@@ -1344,8 +1344,8 @@ sealed class KmpTarget<T: KotlinTarget> {
                 class X86(
                     override val pluginIds: Set<String>? = null,
                     override val target: (KotlinNativeTarget.() -> Unit)? = null,
-                    override val mainSourceSet: ((KotlinSourceSet) -> Unit)? = null,
-                    override val testSourceSet: ((KotlinSourceSet) -> Unit)? = null
+                    override val mainSourceSet: (KotlinSourceSet.() -> Unit)? = null,
+                    override val testSourceSet: (KotlinSourceSet.() -> Unit)? = null
                 ) : Mingw<KotlinNativeTarget>() {
 
                     companion object {

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
@@ -86,6 +86,8 @@ sealed class KmpTarget<T: KotlinTarget> {
         val IOS_SIMULATOR_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.SOURCE_SET_MAIN_NAME
         val IOS_SIMULATOR_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.SOURCE_SET_TEST_NAME
 
+        val MACOS_COMMON_MAIN get() = NonJvm.Native.Unix.Darwin.Macos.MACOS_COMMON_MAIN
+        val MACOS_COMMON_TEST get() = NonJvm.Native.Unix.Darwin.Macos.MACOS_COMMON_TEST
         val MACOS_ARM64_MAIN get() = NonJvm.Native.Unix.Darwin.Macos.Arm64.SOURCE_SET_MAIN_NAME
         val MACOS_ARM64_TEST get() = NonJvm.Native.Unix.Darwin.Macos.Arm64.SOURCE_SET_TEST_NAME
         val MACOS_X64_MAIN get() = NonJvm.Native.Unix.Darwin.Macos.X64.SOURCE_SET_MAIN_NAME
@@ -480,12 +482,20 @@ sealed class KmpTarget<T: KotlinTarget> {
                         project.kotlin {
                             sourceSets {
                                 maybeCreate(sourceSetMainName).apply sourceSetMain@ {
-                                    dependsOn(getByName(DARWIN_COMMON_MAIN))
+                                    if (this@Darwin is Macos) {
+                                        dependsOn(getByName(Macos.MACOS_COMMON_MAIN))
+                                    } else {
+                                        dependsOn(getByName(DARWIN_COMMON_MAIN))
+                                    }
 
                                     mainSourceSet?.invoke(this@sourceSetMain)
                                 }
                                 maybeCreate(sourceSetTestName).apply sourceSetTest@ {
-                                    dependsOn(getByName(DARWIN_COMMON_TEST))
+                                    if (this@Darwin is Macos) {
+                                        dependsOn(getByName(Macos.MACOS_COMMON_TEST))
+                                    } else {
+                                        dependsOn(getByName(DARWIN_COMMON_TEST))
+                                    }
 
                                     testSourceSet?.invoke(this@sourceSetTest)
                                 }
@@ -678,6 +688,11 @@ sealed class KmpTarget<T: KotlinTarget> {
                     }
 
                     sealed class Macos : Darwin<KotlinNativeTargetWithHostTests>() {
+
+                        companion object {
+                            const val MACOS_COMMON_MAIN = "macosCommon$MAIN"
+                            const val MACOS_COMMON_TEST = "macosCommon$TEST"
+                        }
 
                         class Arm64(
                             override val pluginIds: Set<String>? = null,

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/util/KotlinMultiplatformExt.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/util/KotlinMultiplatformExt.kt
@@ -232,6 +232,20 @@ inline fun KotlinMultiplatformExtension.sourceSetMacosArm64Main(crossinline acti
 inline val KotlinMultiplatformExtension.sourceSetMacosArm64Main: KotlinSourceSet?
     get() = sourceSets.findByName(KmpTarget.SetNames.MACOS_ARM64_MAIN)
 
+inline fun KotlinMultiplatformExtension.sourceSetMacosCommonMain(crossinline action: KotlinSourceSet.() -> Unit) {
+    sourceSetMacosCommonMain?.let { action.invoke(it) }
+}
+
+inline val KotlinMultiplatformExtension.sourceSetMacosCommonMain: KotlinSourceSet?
+    get() = sourceSets.findByName(KmpTarget.SetNames.MACOS_COMMON_MAIN)
+
+inline fun KotlinMultiplatformExtension.sourceSetMacosCommonTest(crossinline action: KotlinSourceSet.() -> Unit) {
+    sourceSetMacosCommonTest?.let { action.invoke(it) }
+}
+
+inline val KotlinMultiplatformExtension.sourceSetMacosCommonTest: KotlinSourceSet?
+    get() = sourceSets.findByName(KmpTarget.SetNames.MACOS_COMMON_TEST)
+
 inline fun KotlinMultiplatformExtension.sourceSetMacosArm64Test(crossinline action: KotlinSourceSet.() -> Unit) {
     sourceSetMacosArm64Test?.let { action.invoke(it) }
 }


### PR DESCRIPTION
* add java 1.8 declaration to match kotlin's jvm target

* add nonJvm source set dependency to native sets

* fix stdlib dependency not being applied to native targets when no jvm targets are elected

* add new source set for macos common code

* fix mingw source set dsl declaration