### PR TITLE
Bump Dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,6 @@ kotlin.code.style=official
 kapt.incremental.apt=true
 # Enable android.databinding.annotationprocessor.ProcessDataBinding (DYNAMIC)
 android.databinding.incremental=true
-# Decrease gradle builds time
-kapt.use.worker.api=true
 # turn off AP discovery in compile path, and therefore turn on Compile Avoidance
 kapt.include.compile.classpath=false
 # Enable In Logcat to determine Kapt

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
@@ -20,13 +20,13 @@ package io.matthewnelson.kotlin.components.dependencies
 object versions {
 
     object android {
-        const val buildTools                = "32.0.0"
-        const val sdkCompile                = 32
+        const val buildTools                = "31.0.0"
+        const val sdkCompile                = 31
         const val sdkMin16                  = 16
         const val sdkMin21                  = 21
         const val sdkMin23                  = 23
         const val sdkMin26                  = 26
-        const val sdkTarget                 = 32
+        const val sdkTarget                 = 31
     }
 
     object androidx {
@@ -89,7 +89,7 @@ object versions {
         const val okhttp                    = "4.9.3"
         const val okio                      = "3.1.0"
         const val leakCanary                = "2.9.1"
-        const val moshi                     = "1.13.0"
+        const val moshi                     = "1.12.0"
         const val sqlDelight                = "1.5.3"
         const val turbine                   = "0.8.0"
     }
@@ -106,7 +106,7 @@ object versions {
     const val viewBindingDelegate           = "1.5.6"
 
     object gradle {
-        const val android                   = "7.2.1"
+        const val android                   = "7.0.4"
         const val atomicfu                  = versions.kotlin.atomicfu
         const val exhaustive                = versions.square.exhaustive
         const val dokka                     = versions.kotlin.kotlin

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
@@ -20,13 +20,13 @@ package io.matthewnelson.kotlin.components.dependencies
 object versions {
 
     object android {
-        const val buildTools                = "31.0.0"
-        const val sdkCompile                = 31
+        const val buildTools                = "32.0.0"
+        const val sdkCompile                = 32
         const val sdkMin16                  = 16
         const val sdkMin21                  = 21
         const val sdkMin23                  = 23
         const val sdkMin26                  = 26
-        const val sdkTarget                 = 31
+        const val sdkTarget                 = 32
     }
 
     object androidx {

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/kotlin/components/dependencies/deps.kt
@@ -31,11 +31,11 @@ object versions {
 
     object androidx {
         const val annotation                = "1.3.0"
-        const val appCompat                 = "1.4.1"
+        const val appCompat                 = "1.4.2"
         const val camera                    = "1.1.0-beta03"
         const val cameraExt                 = "1.1.0-beta03"
-        const val constraintLayout          = "2.1.3"
-        const val core                      = "1.7.0"
+        const val constraintLayout          = "2.1.4"
+        const val core                      = "1.8.0"
         const val exifInterface             = "1.3.3"
         const val lifecycle                 = "2.4.1"
         const val navigation                = "2.4.2"
@@ -59,17 +59,17 @@ object versions {
     }
 
     object kotlin {
-        const val atomicfu                  = "0.17.2"
-        const val coroutines                = "1.6.1"
+        const val atomicfu                  = "0.17.3"
+        const val coroutines                = "1.6.2"
         const val kotlin                    = "1.6.21"
-        const val ktor                      = "2.0.1"
+        const val ktor                      = "2.0.2"
         const val time                      = "0.3.2"
     }
 
     object google {
-        const val hilt                      = "2.41"
+        const val hilt                      = "2.42"
         const val guava                     = "31.1"
-        const val material                  = "1.6.0"
+        const val material                  = "1.6.1"
         const val mlKitBarcodeScanning      = "17.0.2"
         const val zxing                     = "3.5.0"
     }
@@ -77,7 +77,7 @@ object versions {
     const val insetter                      = "0.6.0"
 
     object instacart {
-        const val coil                      = "1.4.0"
+        const val coil                      = "2.1.0"
     }
 
     object javax {
@@ -106,7 +106,7 @@ object versions {
     const val viewBindingDelegate           = "1.5.6"
 
     object gradle {
-        const val android                   = "7.1.3"
+        const val android                   = "7.2.1"
         const val atomicfu                  = versions.kotlin.atomicfu
         const val exhaustive                = versions.square.exhaustive
         const val dokka                     = versions.kotlin.kotlin

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpTarget.kt
@@ -203,9 +203,9 @@ sealed class KmpTarget<T: KotlinTarget> {
 
                         if (this@Jvm is Android) {
                             dependsOn(getByName("androidAndroidTestRelease"))
-                            dependsOn(getByName("androidTestFixtures"))
-                            dependsOn(getByName("androidTestFixturesDebug"))
-                            dependsOn(getByName("androidTestFixturesRelease"))
+//                            dependsOn(getByName("androidTestFixtures"))
+//                            dependsOn(getByName("androidTestFixturesDebug"))
+//                            dependsOn(getByName("androidTestFixturesRelease"))
                         } else {
                             sourceSetJvmJsTest?.let { ss ->
                                 dependsOn(ss)


### PR DESCRIPTION
NOTE: AGP was downgraded to `7.0.4` so project works in latest IntelliJ IDEA release