### PR TITLE
Add extension for configuring from rootProject additional optIn settings

### DIFF
--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationExtension.kt
@@ -166,7 +166,12 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
 
         project.kotlin {
             sourceSets.all {
-                languageSettings.optIn("kotlin.RequiresOptIn")
+                languageSettings {
+                    optIn("kotlin.RequiresOptIn")
+                    KmpRootProjectConfigurationExtension.optInArgs.forEach { arg ->
+                        optIn(arg)
+                    }
+                }
             }
             kotlin?.invoke(this)
         }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationPlugin.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpConfigurationPlugin.kt
@@ -220,6 +220,10 @@ import org.gradle.kotlin.dsl.create
 @Suppress("unused")
 class KmpConfigurationPlugin: Plugin<Project> {
     override fun apply(target: Project) {
-        target.extensions.create<KmpConfigurationExtension>("kmpConfiguration", target)
+        if (target.rootProject == target) {
+            target.extensions.create<KmpRootProjectConfigurationExtension>("kmpProjectConfiguration", target)
+        } else {
+            target.extensions.create<KmpConfigurationExtension>("kmpConfiguration", target)
+        }
     }
 }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpRootProjectConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/KmpRootProjectConfigurationExtension.kt
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2021 Matthew Nelson
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * */
+package io.matthewnelson.kotlin.components.kmp
+
+import org.gradle.api.Project
+import javax.inject.Inject
+
+open class KmpRootProjectConfigurationExtension @Inject constructor(private val project: Project) {
+    fun optInArgs(args: Set<String>) {
+        optInArgs.addAll(args)
+    }
+
+    companion object {
+        internal val optInArgs = mutableSetOf<String>()
+    }
+}


### PR DESCRIPTION
This PR adds a root project extension that enables the ability to add optIn arguments for all modules using the `kmpConfiguration` extension.

```kotlin
// build.gradle.kts
plugins {
    id("kmp-configuration")
}

kmpProjectConfiguration {
    optInArgs(setOf("my.annotation.InternalApi"))
}
```
