### PR TITLE
Set `SonatypeHost.S01` as default publication artifact server

### DIFF
--- a/includeBuild/dependencies/src/main/kotlin/versions.kt
+++ b/includeBuild/dependencies/src/main/kotlin/versions.kt
@@ -52,7 +52,7 @@ object versions {
     object components {
         const val buildConfig               = "3.0.5"
         const val coroutines                = "1.1.5"
-        const val encoding                  = "1.1.5"
+        const val encoding                  = "1.2.0"
 
         object kmptor {
             const val binary                = "4.7.12-2"

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/publish/KmpPublishExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/publish/KmpPublishExtension.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.kotlin.components.kmp.publish
 
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import io.matthewnelson.kotlin.components.kmp.util.propertyExt
 import org.gradle.api.Project
 import org.gradle.plugins.signing.SigningExtension
@@ -145,6 +146,7 @@ open class KmpPublishExtension @Inject constructor(private val project: Project)
 
             project.extensions.configure<MavenPublishPluginExtension>("mavenPublish") {
                 if (config.mavenPublish?.invoke(this, project) == null) {
+                    sonatypeHost = SonatypeHost.S01
                     releaseSigningEnabled = true
                 }
             }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/util/ProjectExt.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/kotlin/components/kmp/util/ProjectExt.kt
@@ -29,7 +29,7 @@ import org.gradle.kotlin.dsl.*
 @Throws(ExtraPropertiesExtension.UnknownPropertyException::class)
 fun Project.includeStagingRepoIfTrue(
     include: Boolean,
-    sonatypeHost: SonatypeHost = SonatypeHost.DEFAULT,
+    sonatypeHost: SonatypeHost = SonatypeHost.S01,
 ): Boolean {
     if (!include) return include
 
@@ -51,7 +51,7 @@ fun Project.includeStagingRepoIfTrue(
 @Suppress("unused")
 fun Project.includeSnapshotsRepoIfTrue(
     include: Boolean,
-    sonatypeHost: SonatypeHost = SonatypeHost.DEFAULT,
+    sonatypeHost: SonatypeHost = SonatypeHost.S01,
 ): Boolean {
     if (!include) return include
 


### PR DESCRIPTION
Closes #136 

Sets the default publication artifact server to `s01.oss.sonatype.org`

Also bumps `encoding` from `1.1.5` -> `1.2.0`